### PR TITLE
Harden order-status callback validation

### DIFF
--- a/Controller/StatusPage/Callback.php
+++ b/Controller/StatusPage/Callback.php
@@ -6,11 +6,14 @@ use Spectrocoin\Merchant\Library\SCMerchantClient\Data\OrderCallback;
 
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
+use Magento\Framework\App\CsrfAwareActionInterface;
+use Magento\Framework\App\Request\InvalidRequestException;
+use Magento\Framework\App\RequestInterface;
 use Magento\Sales\Model\Order;
 use Magento\Framework\App\Request\Http;
 
 
-class Callback extends Action {
+class Callback extends Action implements CsrfAwareActionInterface {
     protected $order;
     protected $paymentModel;
     protected $client;
@@ -36,23 +39,77 @@ class Callback extends Action {
         $this->httpRequest = $request;
     }
 
+    /**
+     * This is an unauthenticated, externally reachable webhook. Magento's
+     * form-key CSRF protection does not apply to server-to-server callbacks,
+     * so we opt out of it here — the cryptographic signature check in
+     * execute() is what actually authenticates the request.
+     */
+    public function createCsrfValidationException(RequestInterface $request): ?InvalidRequestException
+    {
+        return null;
+    }
+
+    public function validateForCsrf(RequestInterface $request): ?bool
+    {
+        return true;
+    }
 
     /**
-     * Default customer account page
+     * Handle a SpectroCoin order-status callback.
+     *
+     * Security: the callback status is attacker-controllable, so nothing here
+     * may trust it until the RSA signature has been verified against
+     * SpectroCoin's public certificate. Prior to this fix the signature was
+     * never checked, allowing an unauthenticated attacker to POST a forged
+     * "paid" (status=3) callback for their own order and have it marked
+     * complete without paying.
      *
      * @return void
      */
     public function execute() {
-        $orderCallback = $this->client->parseCreateOrderCallback($_REQUEST);
+        // 1. Callbacks are server-to-server POSTs. Reject anything else so a
+        //    forged callback cannot be triggered via a simple GET link.
+        if (!$this->httpRequest->isPost()) {
+            $this->getResponse()->setBody('*error*');
+            return;
+        }
 
-        if (!is_null($orderCallback)) {
-            $order = $this->order->loadByIncrementId($orderCallback->getOrderId());
-            if ($this->paymentModel->updateOrderStatus($orderCallback, $order)) {
-                $this->getResponse()->setBody('*ok*');
-            }
-            else {
-                $this->getResponse()->setBody('*error*');
-            }
+        // 2. Parse from the POST body only (never $_REQUEST, which also mixes
+        //    in GET/cookie data).
+        $orderCallback = $this->client->parseCreateOrderCallback($this->httpRequest->getPostValue());
+        if (is_null($orderCallback)) {
+            $this->getResponse()->setBody('*error*');
+            return;
+        }
+
+        // 3. Cryptographically verify the signature BEFORE loading or mutating
+        //    any order. This is the fix for the unauthenticated payment bypass.
+        if (!$this->client->validateCreateOrderCallback($orderCallback)) {
+            $this->getResponse()->setBody('*error*');
+            return;
+        }
+
+        $order = $this->order->loadByIncrementId($orderCallback->getOrderId());
+
+        // 4. The order must exist and must actually be a SpectroCoin payment
+        //    order, so a valid callback for one merchant/order cannot be
+        //    replayed against an unrelated order.
+        if (!$order->getId()
+            || $order->getPayment() === null
+            || $order->getPayment()->getMethod() !== PaymentModel::CODE) {
+            $this->getResponse()->setBody('*error*');
+            return;
+        }
+
+        // 5. The signed amount/currency must match the Magento order.
+        if (!$this->paymentModel->matchesOrder($orderCallback, $order)) {
+            $this->getResponse()->setBody('*error*');
+            return;
+        }
+
+        if ($this->paymentModel->updateOrderStatus($orderCallback, $order)) {
+            $this->getResponse()->setBody('*ok*');
         }
         else {
             $this->getResponse()->setBody('*error*');

--- a/Library/SCMerchantClient/SCMerchantClient.php
+++ b/Library/SCMerchantClient/SCMerchantClient.php
@@ -48,6 +48,18 @@ class SCMerchantClient {
     public function setPrivateMerchantKey($privateKey) {
         $this->privateMerchantKey = $privateKey;
     }
+
+    /**
+     * Override the location (URL or local file path) of the SpectroCoin public
+     * certificate used to verify callback signatures. Defaults to the remote
+     * URL; pinning a locally shipped copy avoids an unauthenticated network
+     * fetch on every callback and makes signature verification testable.
+     *
+     * @param string $location
+     */
+    public function setPublicSpectroCoinCertLocation($location) {
+        $this->publicSpectroCoinCertLocation = $location;
+    }
     
     /**
      * @param CreateOrderRequest $request
@@ -184,7 +196,19 @@ class SCMerchantClient {
 	{
 		$sig = base64_decode($signature);
 		$publicKey = file_get_contents($this->publicSpectroCoinCertLocation);
+		if ($publicKey === false) {
+			return -1;
+		}
 		$public_key_pem = openssl_pkey_get_public($publicKey);
+		if ($public_key_pem === false) {
+			return -1;
+		}
+		// NOTE (secondary weakness): SpectroCoin's legacy merchant API signs
+		// callbacks with RSA-SHA1, so the verifier must use SHA1 to match the
+		// signer. SHA1 is deprecated; the newer SpectroCoin plugins instead
+		// fetch the authoritative order status from the API with merchant
+		// credentials rather than trusting a caller-supplied, SHA1-signed
+		// payload. Migrating to that scheme is the recommended follow-up.
 		$r = openssl_verify($data, $sig, $public_key_pem, OPENSSL_ALGO_SHA1);
 
 		return $r;

--- a/Model/Payment.php
+++ b/Model/Payment.php
@@ -268,6 +268,32 @@ class Payment extends AbstractMethod {
         return $statusOption;
     }
 
+    /**
+     * Defence-in-depth check that a (signature-verified) callback actually
+     * refers to this Magento order: the currency must match and the callback
+     * amount must equal the order grand total. The fiat total lives in
+     * payAmount or receiveAmount depending on the configured order payment
+     * method, so either matching is accepted.
+     *
+     * @param OrderCallback $callback
+     * @param Order $order
+     * @return bool
+     */
+    public function matchesOrder(OrderCallback $callback, Order $order) {
+        $orderCurrency = $order->getOrderCurrencyCode();
+        if ($callback->getReceiveCurrency() !== $orderCurrency
+            && $callback->getPayCurrency() !== $orderCurrency) {
+            return false;
+        }
+
+        $grandTotal = (float) number_format($order->getGrandTotal(), 2, '.', '');
+        $payAmount = (float) $callback->getPayAmount();
+        $receiveAmount = (float) $callback->getReceiveAmount();
+
+        return abs($grandTotal - $payAmount) < 0.01
+            || abs($grandTotal - $receiveAmount) < 0.01;
+    }
+
     public function updateOrderStatus(OrderCallback $callback, Order $order) {
         try {
             $orderState = $this->getOrderStatus($callback->getStatus());

--- a/Test/Unit/CallbackSignatureTest.php
+++ b/Test/Unit/CallbackSignatureTest.php
@@ -1,0 +1,183 @@
+<?php
+namespace Spectrocoin\Merchant\Test\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Spectrocoin\Merchant\Library\SCMerchantClient\SCMerchantClient;
+use Spectrocoin\Merchant\Library\SCMerchantClient\Data\OrderCallback;
+
+/**
+ * Regression test for the unauthenticated payment-bypass fix.
+ *
+ * Reproduces the reported vulnerability: an attacker POSTs a "paid" callback
+ * (status=3) for their own order with a bogus signature. Before the fix the
+ * signature was never checked and such a callback was accepted. This test
+ * asserts SCMerchantClient::validateCreateOrderCallback() rejects a forged
+ * signature and accepts only a callback correctly signed with SpectroCoin's
+ * private key.
+ */
+class CallbackSignatureTest extends TestCase
+{
+    /** @var string PEM of a throwaway private key standing in for SpectroCoin's signer */
+    private $privateKeyPem;
+
+    /** @var string temp file holding the matching public certificate */
+    private $publicKeyFile;
+
+    /** @var string */
+    private $userId = 'test-user';
+
+    /** @var string */
+    private $merchantApiId = 'test-api';
+
+    protected function setUp(): void
+    {
+        $res = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+        $this->assertNotFalse($res, 'Could not generate a test RSA key');
+
+        openssl_pkey_export($res, $this->privateKeyPem);
+        $details = openssl_pkey_get_details($res);
+
+        $this->publicKeyFile = tempnam(sys_get_temp_dir(), 'sc_pub_') . '.pem';
+        file_put_contents($this->publicKeyFile, $details['key']);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->publicKeyFile && file_exists($this->publicKeyFile)) {
+            unlink($this->publicKeyFile);
+        }
+    }
+
+    private function makeClient(): SCMerchantClient
+    {
+        $client = new SCMerchantClient('https://spectrocoin.com/api/merchant/1', $this->userId, $this->merchantApiId, false);
+        // Verify against our locally generated public key instead of the live URL.
+        $client->setPublicSpectroCoinCertLocation($this->publicKeyFile);
+        return $client;
+    }
+
+    /**
+     * Build the callback field set. When $sign is null the payload is signed
+     * with the test private key exactly as SpectroCoin's server would, using
+     * the same field order/formatting that validateCreateOrderCallback expects.
+     */
+    private function makeCallback($sign = null): OrderCallback
+    {
+        $values = [
+            'userId'         => $this->userId,
+            'merchantApiId'  => $this->merchantApiId,
+            'merchantId'     => 10,
+            'apiId'          => 20,
+            'orderId'        => '100000001',
+            'payCurrency'    => 'EUR',
+            'payAmount'      => 25.00,
+            'receiveCurrency'=> 'EUR',
+            'receiveAmount'  => 25.00,
+            'receivedAmount' => 25.00,
+            'description'    => '',
+            'orderRequestId' => 999,
+            'status'         => 3, // Paid
+        ];
+
+        $build = function ($signValue) use ($values) {
+            return new OrderCallback(
+                $values['userId'], $values['merchantApiId'], $values['merchantId'],
+                $values['apiId'], $values['orderId'], $values['payCurrency'],
+                $values['payAmount'], $values['receiveCurrency'], $values['receiveAmount'],
+                $values['receivedAmount'], $values['description'], $values['orderRequestId'],
+                $values['status'], $signValue
+            );
+        };
+
+        if ($sign !== null) {
+            return $build($sign);
+        }
+
+        // Reproduce the verifier's signed payload from the getter values.
+        $c = $build('placeholder');
+        $payload = [
+            'merchantId'     => $c->getMerchantId(),
+            'apiId'          => $c->getApiId(),
+            'orderId'        => $c->getOrderId(),
+            'payCurrency'    => $c->getPayCurrency(),
+            'payAmount'      => $c->getPayAmount(),
+            'receiveCurrency'=> $c->getReceiveCurrency(),
+            'receiveAmount'  => $c->getReceiveAmount(),
+            'receivedAmount' => $c->getReceivedAmount(),
+            'description'    => $c->getDescription(),
+            'orderRequestId' => $c->getOrderRequestId(),
+            'status'         => $c->getStatus(),
+        ];
+        $data = http_build_query($payload);
+        $pkeyid = openssl_pkey_get_private($this->privateKeyPem);
+        openssl_sign($data, $signature, $pkeyid, OPENSSL_ALGO_SHA1);
+
+        return $build(base64_encode($signature));
+    }
+
+    public function testForgedSignatureIsRejected(): void
+    {
+        $client = $this->makeClient();
+        $forged = $this->makeCallback(base64_encode('this-is-not-a-valid-signature'));
+
+        $this->assertFalse(
+            $client->validateCreateOrderCallback($forged),
+            'A callback with a forged signature must be rejected'
+        );
+    }
+
+    public function testEmptySignatureIsRejected(): void
+    {
+        $client = $this->makeClient();
+        $empty = $this->makeCallback('');
+
+        $this->assertFalse(
+            $client->validateCreateOrderCallback($empty),
+            'A callback with an empty signature must be rejected'
+        );
+    }
+
+    public function testTamperedStatusIsRejected(): void
+    {
+        // Sign a legitimate payload, then flip the status to Paid (3). The
+        // signature no longer covers the mutated field, so it must fail.
+        $client = $this->makeClient();
+        $signed = $this->makeCallback();
+
+        $tampered = new OrderCallback(
+            $this->userId, $this->merchantApiId, 10, 20, '100000001', 'EUR', 25.00,
+            'EUR', 25.00, 0.00, '', 999, 3, $signed->getSign()
+        );
+
+        // receivedAmount was changed from 25.00 to 0.00, so the signature is invalid.
+        $this->assertFalse(
+            $client->validateCreateOrderCallback($tampered),
+            'A callback whose signed fields were tampered with must be rejected'
+        );
+    }
+
+    public function testWrongMerchantIsRejected(): void
+    {
+        // Correctly signed, but the client belongs to a different merchant.
+        $client = new SCMerchantClient('https://spectrocoin.com/api/merchant/1', 'other-user', 'other-api', false);
+        $client->setPublicSpectroCoinCertLocation($this->publicKeyFile);
+
+        $this->assertFalse(
+            $client->validateCreateOrderCallback($this->makeCallback()),
+            'A callback for a different merchant must be rejected'
+        );
+    }
+
+    public function testValidSignatureIsAccepted(): void
+    {
+        $client = $this->makeClient();
+
+        $this->assertTrue(
+            $client->validateCreateOrderCallback($this->makeCallback()),
+            'A correctly signed callback must be accepted'
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "spectrocoin/magento2merchant",
   "type": "magento2-module",
   "description": "SpectroCoin cryptocurrency payment gateway for Magento2",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "keywords": [
     "bitcoin",
     "btc",


### PR DESCRIPTION
## Summary

Hardens handling of incoming order-status callbacks in `Controller/StatusPage/Callback.php` and the related client/model classes, and adds unit coverage.

## Changes

- Validate the incoming order-status callback before loading or updating the order.
- Process callbacks over POST only and read from `getPostValue()` instead of `$_REQUEST`.
- Confirm the referenced order exists, is a SpectroCoin payment order, and that the callback amount/currency match the Magento order (`Payment::matchesOrder()`).
- Implement `CsrfAwareActionInterface` for this server-to-server endpoint.
- Guard against public-key fetch/parse failures and add `setPublicSpectroCoinCertLocation()` so the certificate can be pinned locally (also makes the flow unit-testable).

## Tests

Adds `Test/Unit/CallbackSignatureTest.php` covering callback validation: invalid, empty, tampered, and mismatched-merchant callbacks are rejected; a well-formed one is accepted.