### PR TITLE
1.0.3: drop unused nategood/httpful dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "spectrocoin/magento2merchant",
   "type": "magento2-module",
   "description": "SpectroCoin cryptocurrency payment gateway for Magento2",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "keywords": [
     "bitcoin",
     "btc",
@@ -17,7 +17,6 @@
   ],
   "homepage": "https://spectrocoin.com",
   "require": {
-    "nategood/httpful": "*",
     "guzzlehttp/guzzle": "^7.8"
   },
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b2697cbb8ff8c33d28b6f9ff7a36025",
+    "content-hash": "710f8373901bbccda913622a489a5617",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -336,60 +336,6 @@
                 }
             ],
             "time": "2026-07-16T22:23:49+00:00"
-        },
-        {
-            "name": "nategood/httpful",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nategood/httpful.git",
-                "reference": "ea02c8aedef70b9a453ce97978d9d7c413972f15"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nategood/httpful/zipball/ea02c8aedef70b9a453ce97978d9d7c413972f15",
-                "reference": "ea02c8aedef70b9a453ce97978d9d7c413972f15",
-                "shasum": ""
-            },
-            "require": {
-                "ext-curl": "*",
-                "php": ">=8.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^10.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Httpful": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nate Good",
-                    "email": "me@nategood.com",
-                    "homepage": "http://nategood.com"
-                }
-            ],
-            "description": "A Readable, Chainable, REST friendly, PHP HTTP Client",
-            "homepage": "http://github.com/nategood/httpful",
-            "keywords": [
-                "api",
-                "curl",
-                "http",
-                "requests",
-                "rest",
-                "restful"
-            ],
-            "support": {
-                "issues": "https://github.com/nategood/httpful/issues",
-                "source": "https://github.com/nategood/httpful/tree/v1.0.0"
-            },
-            "time": "2024-05-01T11:33:16+00:00"
         },
         {
             "name": "psr/http-client",


### PR DESCRIPTION
`nategood/httpful` is declared in `composer.json` but referenced nowhere in the extension - all HTTP calls go through `guzzlehttp/guzzle`. Removing it drops a package from every merchant's install footprint.

Done with `composer remove`, so `composer.lock` is regenerated and stays consistent with the manifest; `composer validate` passes (only the two pre-existing warnings about the deprecated SPDX id and the `version` field).

Version bumped 1.0.2 -> 1.0.3. This repo has no release automation, so the tag/release is manual.